### PR TITLE
option to emit every frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ dataSource.pipe(requestAnimationStream()).pipe(viewLayer)
 
 ## API
 
-### `requestAnimationStream(_flush) -> DuplexStream`
+### `requestAnimationStream(_flush, _alwaysEmit) -> DuplexStream`
 
 * `_flush` is an optional argument that determines if any buffered data will be
   emitted if the stream is ended before the next frame.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ dataSource.pipe(requestAnimationStream()).pipe(viewLayer)
 * `_flush` is an optional argument that determines if any buffered data will be
   emitted if the stream is ended before the next frame.
 
+* `_alwaysEmit` is an optional argument that determines if the stream will emit
+  every frame, even if no new data (most recent data will be emitted.)
+
 ## license
 
 MIT

--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@ var through = require('through')
 
 module.exports = requestAnimationStream
 
-function requestAnimationStream(flush) {
+function requestAnimationStream(flush, _alwaysEmit) {
   var lastValue = null
   var stream = through(write, end)
   var handler = raf(onFrame)
 
   var queued = false
   var ended = false
+  var alwaysEmit = _alwaysEmit || false
 
   return stream
 
@@ -33,7 +34,7 @@ function requestAnimationStream(flush) {
       return
     }
 
-    if(queued) {
+    if(queued || alwaysEmit) {
       queued = false
       stream.queue(lastValue)
     }

--- a/test/index.js
+++ b/test/index.js
@@ -77,3 +77,22 @@ test('flush option writes any buffered, unwritten data on end', function(t) {
   stream.write('flush!')
   stream.end()
 })
+
+test('emits after raf callback even with no update', function(t) {
+  t.plan(2)
+
+  var rAS = proxyquire('../', {raf: asyncRaf})
+
+  var stream = rAS(true, true)
+
+  stream.once('data', function(data) {
+    t.equal(data, 'yay')
+
+    stream.once('data', function(data) {
+      t.equal(data, 'yay')
+      stream.end()
+    })
+  })
+
+  stream.write('yay')
+})


### PR DESCRIPTION
This adds an option to request-animation-stream to cause the stream to emit the last scene data every frame, whether or not any new data has been written to it.

This will allow users of the stream to read from the stream for data, but still run any animation logic that is not dependent on the data coming from this stream without having to worry about race conditions if registering their own requestAnimationFrame callbacks
